### PR TITLE
兼容暴力猴2.12.8以上版本。

### DIFF
--- a/秒传链接提取(es6).js
+++ b/秒传链接提取(es6).js
@@ -404,7 +404,7 @@
             onload: function (r) {
                 if (parseInt(r.status / 100) === 2) {
                     var responseHeaders = r.responseHeaders;
-                    var file_md5 = responseHeaders.match(/content-md5: ([\da-f]{32})/);
+                    var file_md5 = responseHeaders.match(/content-md5: ([\da-f]{32})/i);
                     if (file_md5) {
                         file_md5 = file_md5[1];
                     } else {

--- a/秒传链接提取(es6).js
+++ b/秒传链接提取(es6).js
@@ -21,7 +21,7 @@
 // @run-at            document-start
 // @connect           *
 // ==/UserScript==
-! function () {
+!function () {
     'use strict';
     const info_url = 'https://pan.baidu.com/rest/2.0/xpan/nas?method=uinfo'
     const api_url = 'http://pan.baidu.com/rest/2.0/xpan/multimedia?method=listall&order=name&limit=10000';
@@ -57,6 +57,21 @@
 
     if (Base64.extendString) {
         Base64.extendString();
+    }
+
+    const request = (opts) => {
+        return new Promise((resolve, reject) => {
+            GM_xmlhttpRequest({
+                    ...opts,
+                    onload(res) {
+                        resolve(res)
+                    },
+                    onerror(err) {
+                        reject(err);
+                    },
+                }
+            );
+        })
     }
 
     function add_file_list(file_list) {
@@ -107,7 +122,7 @@
         }
         var path = dir_list[dir_id];
         var list_dir_par = {
-            url: api_url + `&path=${encodeURIComponent(path)}&recursion=${recursive?1:0}`,
+            url: api_url + `&path=${encodeURIComponent(path)}&recursion=${recursive ? 1 : 0}`,
             type: 'GET',
             responseType: 'json',
             onload: function (r) {
@@ -138,7 +153,7 @@
     }
 
     function initButtonEvent() {
-        $(document).on("click", ".gen-bdlink-button", function () {
+        $(document).on('click', '.gen-bdlink-button', function () {
             if (!GM_getValue('gen_no_first_1.3.3')) {
                 Swal.fire({
                     title: '首次使用请注意',
@@ -186,11 +201,11 @@
 
     function initButtonHome() {
         let loop = setInterval(() => {
-            var html_tag = $("div.tcuLAu");
+            var html_tag = $('div.tcuLAu');
             if (!html_tag.length) return false;
             html_tag.append(html_btn);
             let loop2 = setInterval(() => {
-                var btn_tag = $("#bdlink_btn");
+                var btn_tag = $('#bdlink_btn');
                 if (!btn_tag.length) return false;
                 btn_tag.click(function () {
                     GetInfo();
@@ -202,7 +217,7 @@
     }
 
     function initButtonGen() {
-        var listTools = getSystemContext().Broker.getButtonBroker("listTools");
+        var listTools = getSystemContext().Broker.getButtonBroker('listTools');
         if (listTools && listTools.$box) {
             $(listTools.$box).children('div').after(html_btn_gen);
             initButtonEvent();
@@ -212,7 +227,7 @@
     };
 
     function getSystemContext() {
-        return unsafeWindow.require("system-core:context/context.js").instanceForSystem;
+        return unsafeWindow.require('system-core:context/context.js').instanceForSystem;
     };
 
     function Gen_bdlink(file_id = 0) {
@@ -275,7 +290,7 @@
     }
 
     var show_prog = function (r) {
-        gen_prog.textContent = `${parseInt((r.loaded/r.total)*100)}%`;
+        gen_prog.textContent = `${parseInt((r.loaded / r.total) * 100)}%`;
     };
 
     function test_bdlink() {
@@ -341,9 +356,9 @@
                 ...(bdcode && checkbox_par),
                 onBeforeOpen: () => {
                     let loop = setInterval(() => {
-                        var html_tag = $("#check_md5_btn");
+                        var html_tag = $('#check_md5_btn');
                         if (!html_tag.length) return false;
-                        $("#check_md5_btn").click(function () {
+                        $('#check_md5_btn').click(function () {
                             test_bdlink();
                         });
                         clearInterval(loop);
@@ -378,7 +393,7 @@
         }
         var path = file_info.path;
         gen_num.textContent = (file_id + 1).toString() + ' / ' + file_info_list.length.toString();
-        gen_prog.textContent = "0%";
+        gen_prog.textContent = '0%';
 
         var dl_size = file_info.size < 262144 ? file_info.size - 1 : 262143;
         if (!failed) {
@@ -395,7 +410,7 @@
             onprogress: show_prog,
             ontimeout: function (r) {
                 myGenerater(file_id);
-                console.log("timeout !!!");
+                console.log('timeout !!!');
             },
             onerror: function (r) {
                 file_info.errno = 514;
@@ -422,7 +437,7 @@
                         file_info.md5 = file_md5;
                         file_info.md5s = slice_md5;
                     }
-                    gen_prog.textContent = "100%";
+                    gen_prog.textContent = '100%';
                     setTimeout(function () {
                         myGenerater(file_id + 1);
                     }, interval_mode ? interval * 1000 : 1000);
@@ -448,6 +463,7 @@
     function SimpleBuffer(str) {
         this.fromString(str);
     }
+
     SimpleBuffer.toStdHex = function toStdHex(n) {
         return ('0' + n.toString(16)).slice(-2);
     };
@@ -486,7 +502,9 @@
         return Array.prototype.slice.call(this.buf, index, index + size).map(SimpleBuffer.toStdHex).join('');
     };
 
-    function DuParser() {}
+    function DuParser() {
+    }
+
     DuParser.parse = function generalDuCodeParse(szUrl) {
         var r;
         if (szUrl.indexOf('bdpan') === 0) {
@@ -585,7 +603,7 @@
     function saveFile(i, try_flag) {
         if (i >= codeInfo.length) {
             Swal.fire({
-                title: `${check_mode?'测试':'转存'}完毕 共${codeInfo.length}个 失败${failed}个!`,
+                title: `${check_mode ? '测试' : '转存'}完毕 共${codeInfo.length}个 失败${failed}个!`,
                 confirmButtonText: check_mode ? '复制秒传代码' : '确定',
                 showCloseButton: true,
                 html: '',
@@ -650,7 +668,7 @@
         var file = codeInfo[i];
         file_num.textContent = (i + 1).toString() + ' / ' + codeInfo.length.toString();
         $.ajax({
-            url: `/api/rapidupload${check_mode?'?rtype=3':''}`,
+            url: `/api/rapidupload${check_mode ? '?rtype=3' : ''}`,
             type: 'POST',
             data: {
                 path: dir + file.path,
@@ -700,11 +718,11 @@
             case 2:
                 return '转存失败(尝试重新登录网盘账号)';
             case 3939:
-                return `秒传不支持大于20G的文件,文件大小:${(file_size/(1024**3)).toFixed(2)}G`;
-                //文件大于20G时访问秒传接口实际会返回#2
+                return `秒传不支持大于20G的文件,文件大小:${(file_size / (1024 ** 3)).toFixed(2)}G`;
+            //文件大于20G时访问秒传接口实际会返回#2
             case 2333:
                 return '链接内的文件路径错误(不能含有以下字符"\\:*?<>|)';
-                //文件路径错误时接口实际也是返回#2
+            //文件路径错误时接口实际也是返回#2
             case -10:
                 return '网盘容量已满';
             case 114:
@@ -784,8 +802,8 @@
 
     function save_alert() {
         Swal.fire({
-            title: `文件${check_mode?'测试':'提取'}中`,
-            html: `正在${check_mode?'测试':'转存'}第 <file_num></file_num> 个`,
+            title: `文件${check_mode ? '测试' : '提取'}中`,
+            html: `正在${check_mode ? '测试' : '转存'}第 <file_num></file_num> 个`,
             allowOutsideClick: false,
             onBeforeOpen: () => {
                 Swal.showLoading()
@@ -801,7 +819,7 @@
     function GetInfo_url() {
         let bdlink = location.href.match(/[\?#]bdlink=([\da-zA-Z/\+]+)&?/);
         if (bdlink) {
-          bdlink = bdlink[1].fromBase64();
+            bdlink = bdlink[1].fromBase64();
         }
         return bdlink;
     }
@@ -813,11 +831,11 @@
             content.innerHTML += `<p><br></p>`;
             content.innerHTML += html_feedback;
             let loop = setInterval(() => {
-                var html_tag = $("#kill_feedback");
+                var html_tag = $('#kill_feedback');
                 if (!html_tag.length) return false;
-                $("#kill_feedback").click(function () {
+                $('#kill_feedback').click(function () {
                     GM_setValue('kill_feedback', true);
-                    $("#bdcode_feedback").remove();
+                    $('#bdcode_feedback').remove();
                 });
                 clearInterval(loop);
             }, 50);
@@ -828,11 +846,11 @@
             }
             content.innerHTML += html_donate;
             let loop = setInterval(() => {
-                var html_tag = $("#kill_donate");
+                var html_tag = $('#kill_donate');
                 if (!html_tag.length) return false;
-                $("#kill_donate").click(function () {
+                $('#kill_donate').click(function () {
                     GM_setValue('kill_donate', true);
-                    $("#bdcode_donate").remove();
+                    $('#bdcode_donate').remove();
                 });
                 clearInterval(loop);
             }, 50);
@@ -853,36 +871,47 @@
         };
         GM_xmlhttpRequest(info_par);
     }
-    const injectStyle = () => {
-        const style = GM_getResourceText("sweetalert2Css");
+
+    const injectStyle =  () => {
+        let style = GM_getResourceText('sweetalert2Css');
+        // 暴力猴直接粘贴脚本代码时可能不会将resource中的数据下载缓存，fallback到下载css代码
+        if (!style) {
+           request({
+                url: 'https://cdn.jsdelivr.net/npm/sweetalert2@8/dist/sweetalert2.min.css',
+                type: 'GET',
+                responseType: 'text'
+            }).then(res => {
+                style = res.response
+           })
+        }
         GM_addStyle(style);
     };
 
     const showUpdateInfo = () => {
-      if (!GM_getValue("1.4.6_no_first")) {
-        Swal.fire({
-          title: `秒传链接提取 1.4.6 更新内容(21.1.14):`,
-          html: update_info,
-          heightAuto: false,
-          scrollbarPadding: false,
-          showCloseButton: true,
-          allowOutsideClick: false,
-          confirmButtonText: "确定"
-        }).then((result) => {
-          GM_setValue("1.4.6_no_first", true);
-        });
-      }
+        if (!GM_getValue('1.4.6_no_first')) {
+            Swal.fire({
+                title: `秒传链接提取 1.4.6 更新内容(21.1.14):`,
+                html: update_info,
+                heightAuto: false,
+                scrollbarPadding: false,
+                showCloseButton: true,
+                allowOutsideClick: false,
+                confirmButtonText: '确定'
+            }).then((result) => {
+                GM_setValue('1.4.6_no_first', true);
+            });
+        }
     };
 
     function myInit() {
         injectStyle();
         const bdlink = GetInfo_url();
-        window.addEventListener("DOMContentLoaded", () => {
-        bdlink ? GetInfo(bdlink) : showUpdateInfo();
-        initButtonHome();
-        initButtonGen();
-        checkVipType();
-      });
+        window.addEventListener('DOMContentLoaded', () => {
+            bdlink ? GetInfo(bdlink) : showUpdateInfo();
+            initButtonHome();
+            initButtonGen();
+            checkVipType();
+        });
     }
 
     const update_info =

--- a/秒传链接提取.user.js
+++ b/秒传链接提取.user.js
@@ -447,7 +447,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       onload: function onload(r) {
         if (parseInt(r.status / 100) === 2) {
           var responseHeaders = r.responseHeaders;
-          var file_md5 = responseHeaders.match(/content-md5: ([\da-f]{32})/);
+          var file_md5 = responseHeaders.match(/content-md5: ([\da-f]{32})/i);
 
           if (file_md5) {
             file_md5 = file_md5[1];

--- a/秒传链接提取.user.js
+++ b/秒传链接提取.user.js
@@ -9,12 +9,13 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 // ==UserScript==
 // @name              秒传链接提取
 // @namespace         moe.cangku.mengzonefire
-// @version           1.4.8
+// @version           1.4.9
 // @description       用于提取和生成百度网盘秒传链接
 // @author            mengzonefire
 // @match             *://pan.baidu.com/disk/home*
 // @match             *://yun.baidu.com/disk/home*
-// @require           https://cdn.jsdelivr.net/npm/sweetalert2@8
+// @resource sweetalert2Css https://cdn.jsdelivr.net/npm/sweetalert2@8/dist/sweetalert2.min.css
+// @require           https://cdn.jsdelivr.net/npm/sweetalert2@8/dist/sweetalert2.min.js
 // @require           https://cdn.jsdelivr.net/npm/js-base64
 // @require           https://cdn.staticfile.org/spark-md5/3.0.0/spark-md5.min.js
 // @grant             GM_setValue
@@ -23,7 +24,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 // @grant             GM_setClipboard
 // @grant             GM_xmlhttpRequest
 // @grant             GM_info
-// @run-at            document-body
+// @grant             GM_getResourceText
+// @grant             GM_addStyle
+// @run-at            document-start
 // @connect           *
 // ==/UserScript==
 !function () {
@@ -36,21 +39,21 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
   var bad_md5 = ['fcadf26fc508b8039bee8f0901d9c58e', '2d9a55b7d5fe70e74ce8c3b2be8f8e43', 'b912d5b77babf959865100bf1d0c2a19'];
   var select_list,
-      failed = 0,
-      vip_type = 0,
-      interval = 0,
-      check_mode = false,
-      interval_mode = false,
-      file_info_list = [],
-      gen_success_list = [],
-      dir,
-      file_num,
-      gen_num,
-      gen_prog,
-      codeInfo,
-      recursive,
-      bdcode,
-      xmlhttpRequest;
+    failed = 0,
+    vip_type = 0,
+    interval = 0,
+    check_mode = false,
+    interval_mode = false,
+    file_info_list = [],
+    gen_success_list = [],
+    dir,
+    file_num,
+    gen_num,
+    gen_prog,
+    codeInfo,
+    recursive,
+    bdcode,
+    xmlhttpRequest;
   var myStyle = "style=\"width: 100%;height: 34px;display: block;line-height: 34px;text-align: center;\"";
   var myBtnStyle = "style=\"height: 26px;line-height: 26px;vertical-align: middle;\"";
   var html_btn = "<a class=\"g-button g-button-blue href=\"javascript:;\" id=\"bdlink_btn\" title=\"\u79D2\u4F20\u94FE\u63A5\" style=\"display: inline-block;\"\">\n    <span class=\"g-button-right\"><em class=\"icon icon-disk\" title=\"\u79D2\u4F20\u94FE\u63A5\u63D0\u53D6\"></em><span class=\"text\" style=\"width: auto;\">\u79D2\u4F20\u94FE\u63A5</span></span></a>";
@@ -899,24 +902,13 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   }
 
   function GetInfo_url() {
-    var bdlink = href.match(/[\?#]bdlink=([\da-zA-Z/\+]+)&?/);
+    var bdlink = location.href.match(/[\?#]bdlink=([\da-zA-Z/\+]+)&?/);
 
     if (bdlink) {
       bdlink = bdlink[1].fromBase64();
-      GetInfo(bdlink);
-    } else if (!GM_getValue('1.4.6_no_first')) {
-      Swal.fire({
-        title: "\u79D2\u4F20\u94FE\u63A5\u63D0\u53D6 1.4.6 \u66F4\u65B0\u5185\u5BB9(21.1.14):",
-        html: update_info,
-        heightAuto: false,
-        scrollbarPadding: false,
-        showCloseButton: true,
-        allowOutsideClick: false,
-        confirmButtonText: '确定'
-      }).then(function (result) {
-        GM_setValue('1.4.6_no_first', true);
-      });
     }
+
+    return bdlink;
   }
 
   function Add_content(content) {
@@ -972,27 +964,38 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
     GM_xmlhttpRequest(info_par);
   }
 
-  function myInit() {
-    GetInfo_url();
-    initButtonHome();
-    initButtonGen();
-    checkVipType();
-  }
+  var injectStyle = function injectStyle() {
+    var style = GM_getResourceText("sweetalert2Css");
+    GM_addStyle(style);
+  };
 
-  function check_compa() {
-    if (GM_info.scriptHandler === 'Violentmonkey') {
-      if (!GM_getValue('check_compa')) var mymessage = confirm('\"秒传链接提取\" 脚本在 \"暴力猴Violentmonkey\" 插件下可能无法正常运行\n建议更换为 \"油猴Tampermonkey\" 插件, 请问是否继续?');
-
-      if (mymessage) {
-        GM_setValue('check_compa', true);
-        document.addEventListener('DOMContentLoaded', myInit);
-      }
-    } else {
-      document.addEventListener('DOMContentLoaded', myInit);
+  var showUpdateInfo = function showUpdateInfo() {
+    if (!GM_getValue("1.4.6_no_first")) {
+      Swal.fire({
+        title: "\u79D2\u4F20\u94FE\u63A5\u63D0\u53D6 1.4.6 \u66F4\u65B0\u5185\u5BB9(21.1.14):",
+        html: update_info,
+        heightAuto: false,
+        scrollbarPadding: false,
+        showCloseButton: true,
+        allowOutsideClick: false,
+        confirmButtonText: "确定"
+      }).then(function (result) {
+        GM_setValue("1.4.6_no_first", true);
+      });
     }
+  };
+
+  function myInit() {
+    injectStyle();
+    var bdlink = GetInfo_url();
+    window.addEventListener("DOMContentLoaded", function () {
+      bdlink ? GetInfo(bdlink) : showUpdateInfo();
+      initButtonHome();
+      initButtonGen();
+      checkVipType();
+    });
   }
 
   var update_info = "<div class=\"panel-body\" style=\"height: 250px; overflow-y:scroll\">\n        <div style=\"border: 1px  #000000; width: 100%; margin: 0 auto;\"><span>\n\n        <p>\u672C\u6B21\u66F4\u65B0\u9488\u5BF9\u751F\u6210\u529F\u80FD\u505A\u4E86\u4F18\u5316:</p>\n\n        <p>1. \u4F7F\u7528\u8D85\u4F1A\u8D26\u53F7\u8FDB\u884C10\u4E2A\u4EE5\u4E0A\u7684\u6279\u91CF\u79D2\u4F20\u751F\u6210\u65F6, \u4F1A\u5F39\u7A97\u63D0\u793A\u8BBE\u7F6E\u751F\u6210\u95F4\u9694, \u9632\u6B62\u751F\u6210\u8FC7\u5FEB\u5BFC\u81F4\u63A5\u53E3\u88AB\u9650\u5236(#403)</p>\n\n        <p>2. \u4E3A\u79D2\u4F20\u5206\u4EAB\u8005\u63D0\u4F9B\u4E86\u4E00\u4EFD<a href=\"https://shimo.im/docs/TZ1JJuEjOM0wnFDH\" rel=\"noopener noreferrer\" target=\"_blank\">\u9632\u7206\u6559\u7A0B</a>\u7528\u4E8E\u53C2\u8003</p>\n\n        <p><br></p>\n\n        <p>\u82E5\u51FA\u73B0\u4EFB\u4F55\u95EE\u9898\u8BF7\u524D\u5F80<a href=\"https://greasyfork.org/zh-CN/scripts/397324\" rel=\"noopener noreferrer\" target=\"_blank\">greasyfork\u9875</a>\u53CD\u9988</p>\n\n        <p><br></p>\n\n        <p>1.4.5 \u66F4\u65B0\u5185\u5BB9(21.1.12)</p>\n\n        <p>\u4FEE\u590D\u4E861.4.0\u540E\u53EF\u80FD\u51FA\u73B0\u7684\u79D2\u4F20\u6309\u94AE\u65E0\u6548\u3001\u663E\u793A\u591A\u4E2A\u79D2\u4F20\u6309\u94AE\u7684\u95EE\u9898</p>\n\n        <p><br></p>\n\n        <p>1.3.7 \u66F4\u65B0\u5185\u5BB9(21.1.3):</p>\n\n        <p>\u4FEE\u590D\u4E86\u4F1A\u5458\u8D26\u53F7\u751F\u621050M\u4EE5\u4E0B\u6587\u4EF6\u65F6\u63D0\u793A \"md5\u83B7\u53D6\u5931\u8D25\" \u7684\u95EE\u9898</p>\n\n        <p><br></p>\n\n        <p>1.3.3 \u66F4\u65B0\u5185\u5BB9(20.12.1):</p>\n\n        <p>\u79D2\u4F20\u751F\u6210\u5B8C\u6210\u540E\u70B9\u51FB\u590D\u5236\u6309\u94AE\u4E4B\u524D\u90FD\u53EF\u4EE5\u7EE7\u7EED\u4EFB\u52A1,\u9632\u6B62\u8BEF\u64CD\u4F5C\u5173\u95ED\u9875\u9762\u5BFC\u81F4\u751F\u6210\u7ED3\u679C\u4E22\u5931</p>\n\n        <p>\u4FEE\u6539\u4EE3\u7801\u6267\u884C\u987A\u5E8F\u9632\u6B62\u79D2\u4F20\u6309\u94AE\u51FA\u73B0\u5728\u6700\u5DE6\u7AEF</p>\n\n        <p>\u4FEE\u590D\u4E86\u8DE8\u57DF\u63D0\u793A\u4E2D\u5931\u6548\u7684\u8BF4\u660E\u56FE\u7247</p>\n\n        <p><br></p>\n\n        <p>1.2.9 \u66F4\u65B0\u5185\u5BB9(20.11.11):</p>\n        \n        <p>\u751F\u6210\u79D2\u4F20\u7684\u5F39\u7A97\u6DFB\u52A0\u4E86\u5173\u95ED\u6309\u94AE</p>\n        \n        <p>\u5220\u9664\u4E86\u5168\u90E8\u751F\u6210\u5931\u8D25\u65F6\u7684\u590D\u5236\u548C\u6D4B\u8BD5\u6309\u94AE</p>\n\n        <p>\u79D2\u4F20\u751F\u6210\u540E\u52A0\u4E86\u4E00\u4E2A\u5BFC\u51FA\u6587\u4EF6\u8DEF\u5F84\u7684\u9009\u9879(\u9ED8\u8BA4\u4E0D\u5BFC\u51FA)</p>\n\n        <p>\u5728\u8F93\u5165\u4FDD\u5B58\u8DEF\u5F84\u7684\u5F39\u7A97\u6DFB\u52A0\u4E86\u6821\u9A8C\uFF0C\u9632\u6B62\u8F93\u5165\u9519\u8BEF\u8DEF\u5F84</p>\n\n        <p><br></p>\n\n        <p>1.2.5 \u66F4\u65B0\u5185\u5BB9(20.11.4):</p>\n        \n        <p>\u4F18\u5316\u6309\u94AE\u6837\u5F0F\uFF0C\u6DFB\u52A0\u4E86md5\u83B7\u53D6\u5931\u8D25\u7684\u62A5\u9519</p>\n\n        <p>\u4FEE\u590D\u4ECEpan.baidu.com\u8FDB\u5165\u540E\u4E0D\u663E\u793A\u751F\u6210\u6309\u94AE\u7684\u95EE\u9898</p>\n        \n        <p><br></p>\n        \n        <p>1.2.4 \u66F4\u65B0\u5185\u5BB9(20.11.2):</p>\n        \n        <p>\u65B0\u589E\u751F\u6210\u79D2\u4F20:</p>\n        \n        <p>\u9009\u62E9\u6587\u4EF6\u6216\u6587\u4EF6\u5939\u540E\u70B9\u51FB \"\u751F\u6210\u79D2\u4F20\" \u5373\u53EF\u5F00\u59CB\u751F\u6210</p>\n        \n        <p><br></p>\n        \n        <p>\u7EE7\u7EED\u672A\u5B8C\u6210\u4EFB\u52A1:</p>\n        \n        <p>\u82E5\u751F\u6210\u79D2\u4F20\u671F\u95F4\u5173\u95ED\u4E86\u7F51\u9875, \u518D\u6B21\u70B9\u51FB \"\u751F\u6210\u79D2\u4F20\" \u5373\u53EF\u7EE7\u7EED\u4EFB\u52A1</p>\n        \n        <p><br></p>\n        \n        <p>\u6D4B\u8BD5\u79D2\u4F20\u529F\u80FD:</p>\n        \n        <p>\u751F\u6210\u5B8C\u6210\u540E, \u70B9\u51FB\"\u6D4B\u8BD5\"\u6309\u94AE, \u4F1A\u81EA\u52A8\u8F6C\u5B58\u5E76\u8986\u76D6\u6587\u4EF6(\u6587\u4EF6\u5185\u5BB9\u4E0D\u53D8), \u4EE5\u68C0\u6D4B\u79D2\u4F20\u6709\u6548\u6027, \u4EE5\u53CA\u4FEE\u590Dmd5\u9519\u8BEF\u9632\u6B62\u79D2\u4F20\u5931\u6548</p>\n        \n        </span></div></div>";
-  var href = window.location.href;
-  check_compa();
+  myInit();
 }();

--- a/秒传链接提取.user.js
+++ b/秒传链接提取.user.js
@@ -39,21 +39,21 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
   var bad_md5 = ['fcadf26fc508b8039bee8f0901d9c58e', '2d9a55b7d5fe70e74ce8c3b2be8f8e43', 'b912d5b77babf959865100bf1d0c2a19'];
   var select_list,
-    failed = 0,
-    vip_type = 0,
-    interval = 0,
-    check_mode = false,
-    interval_mode = false,
-    file_info_list = [],
-    gen_success_list = [],
-    dir,
-    file_num,
-    gen_num,
-    gen_prog,
-    codeInfo,
-    recursive,
-    bdcode,
-    xmlhttpRequest;
+      failed = 0,
+      vip_type = 0,
+      interval = 0,
+      check_mode = false,
+      interval_mode = false,
+      file_info_list = [],
+      gen_success_list = [],
+      dir,
+      file_num,
+      gen_num,
+      gen_prog,
+      codeInfo,
+      recursive,
+      bdcode,
+      xmlhttpRequest;
   var myStyle = "style=\"width: 100%;height: 34px;display: block;line-height: 34px;text-align: center;\"";
   var myBtnStyle = "style=\"height: 26px;line-height: 26px;vertical-align: middle;\"";
   var html_btn = "<a class=\"g-button g-button-blue href=\"javascript:;\" id=\"bdlink_btn\" title=\"\u79D2\u4F20\u94FE\u63A5\" style=\"display: inline-block;\"\">\n    <span class=\"g-button-right\"><em class=\"icon icon-disk\" title=\"\u79D2\u4F20\u94FE\u63A5\u63D0\u53D6\"></em><span class=\"text\" style=\"width: auto;\">\u79D2\u4F20\u94FE\u63A5</span></span></a>";
@@ -71,6 +71,19 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   if (Base64.extendString) {
     Base64.extendString();
   }
+
+  var request = function request(opts) {
+    return new Promise(function (resolve, reject) {
+      GM_xmlhttpRequest(_objectSpread(_objectSpread({}, opts), {}, {
+        onload: function onload(res) {
+          resolve(res);
+        },
+        onerror: function onerror(err) {
+          reject(err);
+        }
+      }));
+    });
+  };
 
   function add_file_list(file_list) {
     var dir_list = [];
@@ -155,7 +168,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   }
 
   function initButtonEvent() {
-    $(document).on("click", ".gen-bdlink-button", function () {
+    $(document).on('click', '.gen-bdlink-button', function () {
       if (!GM_getValue('gen_no_first_1.3.3')) {
         Swal.fire({
           title: '首次使用请注意',
@@ -206,11 +219,11 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
   function initButtonHome() {
     var loop = setInterval(function () {
-      var html_tag = $("div.tcuLAu");
+      var html_tag = $('div.tcuLAu');
       if (!html_tag.length) return false;
       html_tag.append(html_btn);
       var loop2 = setInterval(function () {
-        var btn_tag = $("#bdlink_btn");
+        var btn_tag = $('#bdlink_btn');
         if (!btn_tag.length) return false;
         btn_tag.click(function () {
           GetInfo();
@@ -222,7 +235,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   }
 
   function initButtonGen() {
-    var listTools = getSystemContext().Broker.getButtonBroker("listTools");
+    var listTools = getSystemContext().Broker.getButtonBroker('listTools');
 
     if (listTools && listTools.$box) {
       $(listTools.$box).children('div').after(html_btn_gen);
@@ -235,7 +248,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   ;
 
   function getSystemContext() {
-    return unsafeWindow.require("system-core:context/context.js").instanceForSystem;
+    return unsafeWindow.require('system-core:context/context.js').instanceForSystem;
   }
 
   ;
@@ -378,9 +391,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       }, bdcode && checkbox_par), {}, {
         onBeforeOpen: function onBeforeOpen() {
           var loop = setInterval(function () {
-            var html_tag = $("#check_md5_btn");
+            var html_tag = $('#check_md5_btn');
             if (!html_tag.length) return false;
-            $("#check_md5_btn").click(function () {
+            $('#check_md5_btn').click(function () {
               test_bdlink();
             });
             clearInterval(loop);
@@ -421,7 +434,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
     var path = file_info.path;
     gen_num.textContent = (file_id + 1).toString() + ' / ' + file_info_list.length.toString();
-    gen_prog.textContent = "0%";
+    gen_prog.textContent = '0%';
     var dl_size = file_info.size < 262144 ? file_info.size - 1 : 262143;
 
     if (!failed) {
@@ -438,7 +451,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       onprogress: show_prog,
       ontimeout: function ontimeout(r) {
         myGenerater(file_id);
-        console.log("timeout !!!");
+        console.log('timeout !!!');
       },
       onerror: function onerror(r) {
         file_info.errno = 514;
@@ -468,7 +481,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
             file_info.md5s = slice_md5;
           }
 
-          gen_prog.textContent = "100%";
+          gen_prog.textContent = '100%';
           setTimeout(function () {
             myGenerater(file_id + 1);
           }, interval_mode ? interval * 1000 : 1000);
@@ -919,11 +932,11 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       content.innerHTML += "<p><br></p>";
       content.innerHTML += html_feedback;
       var loop = setInterval(function () {
-        var html_tag = $("#kill_feedback");
+        var html_tag = $('#kill_feedback');
         if (!html_tag.length) return false;
-        $("#kill_feedback").click(function () {
+        $('#kill_feedback').click(function () {
           GM_setValue('kill_feedback', true);
-          $("#bdcode_feedback").remove();
+          $('#bdcode_feedback').remove();
         });
         clearInterval(loop);
       }, 50);
@@ -937,11 +950,11 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       content.innerHTML += html_donate;
 
       var _loop = setInterval(function () {
-        var html_tag = $("#kill_donate");
+        var html_tag = $('#kill_donate');
         if (!html_tag.length) return false;
-        $("#kill_donate").click(function () {
+        $('#kill_donate').click(function () {
           GM_setValue('kill_donate', true);
-          $("#bdcode_donate").remove();
+          $('#bdcode_donate').remove();
         });
         clearInterval(_loop);
       }, 50);
@@ -965,12 +978,23 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   }
 
   var injectStyle = function injectStyle() {
-    var style = GM_getResourceText("sweetalert2Css");
+    var style = GM_getResourceText('sweetalert2Css'); // 暴力猴直接粘贴脚本代码时可能不会将resource中的数据下载缓存，fallback到下载css代码
+
+    if (!style) {
+      request({
+        url: 'https://cdn.jsdelivr.net/npm/sweetalert2@8/dist/sweetalert2.min.css',
+        type: 'GET',
+        responseType: 'text'
+      }).then(function (res) {
+        style = res.response;
+      });
+    }
+
     GM_addStyle(style);
   };
 
   var showUpdateInfo = function showUpdateInfo() {
-    if (!GM_getValue("1.4.6_no_first")) {
+    if (!GM_getValue('1.4.6_no_first')) {
       Swal.fire({
         title: "\u79D2\u4F20\u94FE\u63A5\u63D0\u53D6 1.4.6 \u66F4\u65B0\u5185\u5BB9(21.1.14):",
         html: update_info,
@@ -978,9 +1002,9 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
         scrollbarPadding: false,
         showCloseButton: true,
         allowOutsideClick: false,
-        confirmButtonText: "确定"
+        confirmButtonText: '确定'
       }).then(function (result) {
-        GM_setValue("1.4.6_no_first", true);
+        GM_setValue('1.4.6_no_first', true);
       });
     }
   };
@@ -988,7 +1012,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   function myInit() {
     injectStyle();
     var bdlink = GetInfo_url();
-    window.addEventListener("DOMContentLoaded", function () {
+    window.addEventListener('DOMContentLoaded', function () {
       bdlink ? GetInfo(bdlink) : showUpdateInfo();
       initButtonHome();
       initButtonGen();


### PR DESCRIPTION
兼容暴力猴2.12.8以上版本。
暴力猴在度盘链接重定向后无法获取重定向之前的hash值。所以要在重定向之前获取。
引用的sweetalert2.all.min.js会在执行时自动将css注入到`<head>`中
而暴力猴2.12.8版本@run-at document-start时`<head></head>`可能还没加载完成

那么我们将style和js分开加载,js一开始就require,style文件使用GM_addStyle去注入到文档最新加载的地方,然后在DomContentLoaded之后继续初始化。

同时暴力猴生成秒传链接的时候获取MD5的请求的responseHeaders字段会存在大写字母，匹配MD5正则部分用i标志不区分大小写
